### PR TITLE
Make it work with Ubuntu's sound indicator

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -136,6 +136,7 @@ static void on_bus_acquired (GDBusConnection *connection,
     org_mpris_media_player2_set_can_raise(mpris_media_interface, FALSE);
     org_mpris_media_player2_set_has_track_list(mpris_media_interface, FALSE);
     org_mpris_media_player2_set_identity(mpris_media_interface, "MOC");
+    org_mpris_media_player2_set_desktop_entry(mpris_media_interface, "moc");
     org_mpris_media_player2_set_supported_uri_schemes(mpris_media_interface, uri_schemes);
     org_mpris_media_player2_set_supported_mime_types(mpris_media_interface, mime_type);
     //org_mpris_media_player2_set_desktop_entry (OrgMprisMediaPlayer2 *object, const gchar *value);


### PR DESCRIPTION
For mocp to work with ubuntu's sound indicator, you need to create a `moc.desktop` in your applications folder (any applications folder), and add `moc.desktop` to `com.canonical.indicator.sound` in `interested-media-players` via gsettings (though I think this happens automatically anyway).

However, moc doesn't broadcast the file name of the .desktop file. This fixes that.

Thanks for this awesome MPRIS support!

(If you like having GUI fallback for MOC, consider trying https://github.com/Manishearth/moc/pull/1/ out as well :smile: )
